### PR TITLE
Add ability to set wait time base

### DIFF
--- a/ecsroll.py
+++ b/ecsroll.py
@@ -397,7 +397,7 @@ if __name__ == '__main__':
 
     if args.action.lower() == 'reboot':
         do_cluster_reboot(args.profile, args.cluster)
-    if args.action.lower() == 'replace':
+    elif args.action.lower() == 'replace':
         do_cluster_replace(args.profile, args.cluster)
     else:
         print('ERROR: Don\'t know what to do with action \'{}\'.'.format(args.action))


### PR DESCRIPTION
This allows speeding/slowing things a bit, which may be helpful in some cases.

The reason I did this was that the default 60s wait time for everything seemed a bit too much for me, so I wanted to be able to configure that, but still maintain the fact that some operations take way longer than others.