### PR TITLE
Change profile arg behaviour, add region

### DIFF
--- a/ecsroll.py
+++ b/ecsroll.py
@@ -19,7 +19,8 @@ WAIT_TIME = DEFAULT_WAIT
 
 AUTO_YES = False
 
-INSTANCE_FIELDS = ['ec2InstanceId', 'containerInstanceArn', 'status', 'runningTasksCount', 'pendingTasksCount']
+INSTANCE_FIELDS = ['ec2InstanceId', 'containerInstanceArn',
+                   'status', 'runningTasksCount', 'pendingTasksCount']
 
 
 def yes_or_exit(message):
@@ -30,7 +31,8 @@ def yes_or_exit(message):
             sys.stdout.write('{0} {1} '.format(message, '/'.join(choices)))
             choice = input().lower()
         if choice != 'y':
-            print('Exiting... please review output, and take any manual steps needed to normalize enviroment.')
+            print(
+                'Exiting... please review output, and take any manual steps needed to normalize enviroment.')
             sys.exit(2)
     sys.stdout.write('\n')
 
@@ -70,7 +72,8 @@ def get_cluster_instances(ecs_client, cluster):
         )
         if len(desc.get('containerInstances')) > 0:
             detail = desc['containerInstances'][0]
-            cluster_instances.append([detail[field] for field in INSTANCE_FIELDS])
+            cluster_instances.append([detail[field]
+                                      for field in INSTANCE_FIELDS])
     return cluster_instances
 
 
@@ -90,7 +93,8 @@ def get_autoscaling_groups(as_client, instances):
 
 
 def bump_autoscaling_group(as_client, asg, hop):
-    asg_obj = as_client.describe_auto_scaling_groups(AutoScalingGroupNames=[asg, ])['AutoScalingGroups'][0]
+    asg_obj = as_client.describe_auto_scaling_groups(
+        AutoScalingGroupNames=[asg, ])['AutoScalingGroups'][0]
     as_client.update_auto_scaling_group(
         AutoScalingGroupName=asg,
         MinSize=asg_obj['MinSize'] + hop,
@@ -112,7 +116,8 @@ def set_scalein_protection_for_instances(as_client, asg, cluster_instances, prot
 
 
 def wait_until_instance_count(ecs_client, target_cluster, count, seconds=WAIT_TIME):
-    countdown('Waiting for cluster size change (expected instance count: {})'.format(count), seconds*3)
+    countdown('Waiting for cluster size change (expected instance count: {})'.format(
+        count), seconds*3)
     current_instances = get_cluster_instances(ecs_client, target_cluster)
     if len(current_instances) != count:
         yes_or_exit('There are currently {} instances, but expecting {} - keep waiting?'.format(
@@ -122,7 +127,8 @@ def wait_until_instance_count(ecs_client, target_cluster, count, seconds=WAIT_TI
 
 
 def wait_until_instance_status(ecs_client, target_cluster, instance_id, status):
-    countdown('Waiting for instance {} to have {} status'.format(instance_id, status), WAIT_TIME/2)
+    countdown('Waiting for instance {} to have {} status'.format(
+        instance_id, status), WAIT_TIME/2)
     current_instances = get_cluster_instances(ecs_client, target_cluster)
     for instance in current_instances:
         if instance[INSTANCE_FIELDS.index('ec2InstanceId')] == instance_id:
@@ -130,18 +136,23 @@ def wait_until_instance_status(ecs_client, target_cluster, instance_id, status):
                 return
             else:
                 yes_or_exit('Instance {} has status {} but expecting {} - keep waiting?'.format(
-                    instance_id, instance[INSTANCE_FIELDS.index('status')], status
+                    instance_id, instance[INSTANCE_FIELDS.index(
+                        'status')], status
                 ))
-                wait_until_instance_status(ecs_client, target_cluster, instance_id, status)
+                wait_until_instance_status(
+                    ecs_client, target_cluster, instance_id, status)
             break
-    print('ERROR: wait_until_instance_status cannot find passed instance: {}'.format(instance_id))
+    print('ERROR: wait_until_instance_status cannot find passed instance: {}'.format(
+        instance_id))
     sys.exit(2)
 
 
 def get_overflow_instance_ids(original_instances, current_instances):
     overflow_ids = []
-    original_ec2_ids = [i[INSTANCE_FIELDS.index('ec2InstanceId')] for i in original_instances]
-    current_ec2_ids = [i[INSTANCE_FIELDS.index('ec2InstanceId')] for i in current_instances]
+    original_ec2_ids = [i[INSTANCE_FIELDS.index(
+        'ec2InstanceId')] for i in original_instances]
+    current_ec2_ids = [i[INSTANCE_FIELDS.index(
+        'ec2InstanceId')] for i in current_instances]
     for i, ec2_id in enumerate(current_ec2_ids):
         if ec2_id not in original_ec2_ids:
             overflow_ids.append(
@@ -155,43 +166,51 @@ def get_overflow_instance_ids(original_instances, current_instances):
 
 def activate_instance(ecs_client, target_cluster, instance_id):
     ecs_client.update_container_instances_state(
-        cluster=target_cluster, containerInstances=[instance_id, ], status='ACTIVE'
+        cluster=target_cluster, containerInstances=[
+            instance_id, ], status='ACTIVE'
     )
 
 
 def wait_until_instance_drained(ecs_client, target_cluster, instance_id):
     print('Marking ECS instance {} as DRAINING'.format(instance_id))
     ecs_client.update_container_instances_state(
-        cluster=target_cluster, containerInstances=[instance_id, ], status='DRAINING'
+        cluster=target_cluster, containerInstances=[
+            instance_id, ], status='DRAINING'
     )
 
     drained = False
     while not drained:
-        response = ecs_client.list_tasks(cluster=target_cluster, containerInstance=instance_id, desiredStatus='RUNNING')
+        response = ecs_client.list_tasks(
+            cluster=target_cluster, containerInstance=instance_id, desiredStatus='RUNNING')
         running = len(response['taskArns'])
         drained = (running == 0)
         if not drained:
-            countdown('Waiting for instance {} to drain; currently running {} tasks'.format(instance_id, running), WAIT_TIME)
+            countdown('Waiting for instance {} to drain; currently running {} tasks'.format(
+                instance_id, running), WAIT_TIME)
 
 
 def wait_until_instance_ec2_ok(ec2_client, ec2_instance_id):
     ok = False
     while not ok:
-        response = ec2_client.describe_instance_status(InstanceIds=[ec2_instance_id])
+        response = ec2_client.describe_instance_status(
+            InstanceIds=[ec2_instance_id])
         status = response['InstanceStatuses'][0]['InstanceStatus']['Status']
         ok = (status == 'ok')
         if not ok:
-            countdown('Waiting for instance {} to be \'ok\'; currently \'{}\''.format(ec2_instance_id, status), WAIT_TIME)
+            countdown('Waiting for instance {} to be \'ok\'; currently \'{}\''.format(
+                ec2_instance_id, status), WAIT_TIME)
 
 
 def wait_until_instance_ecs_connected(ecs_client, ecs_instance_id, target_cluster):
     connected = False
     while not connected:
-        response = ecs_client.describe_container_instances(cluster=target_cluster, containerInstances=[ecs_instance_id])
+        response = ecs_client.describe_container_instances(
+            cluster=target_cluster, containerInstances=[ecs_instance_id])
         connected = response['containerInstances'][0]['agentConnected']
         ec2_instance_id = response['containerInstances'][0]['ec2InstanceId']
         if not connected:
-            countdown('Waiting for instance {} to have ECS agent connected'.format(ec2_instance_id), 60)
+            countdown('Waiting for instance {} to have ECS agent connected'.format(
+                ec2_instance_id), 60)
 
 
 def check_instances_protected_from_scale_in(as_client, cluster_instances):
@@ -200,7 +219,8 @@ def check_instances_protected_from_scale_in(as_client, cluster_instances):
     :return: list
     """
     instance_ids = list(map(lambda x: x[0], cluster_instances))
-    instances = as_client.describe_auto_scaling_instances(InstanceIds=instance_ids)
+    instances = as_client.describe_auto_scaling_instances(
+        InstanceIds=instance_ids)
     instances_with_autoscaling_protection = filter(lambda x: x['ProtectedFromScaleIn'] is True,
                                                    instances['AutoScalingInstances'])
     return list(map(lambda x: x['InstanceId'], instances_with_autoscaling_protection))
@@ -208,7 +228,8 @@ def check_instances_protected_from_scale_in(as_client, cluster_instances):
 
 def setup_for_roll(profile, target_cluster):
     if args.provider == PROVIDER_PROFILE:
-        yes_or_exit('Continue, working with AWS profile \'{}\'?'.format(profile))
+        yes_or_exit(
+            'Continue, working with AWS profile \'{}\'?'.format(profile))
         session = boto3.Session(profile_name=profile)
     else:
         session = boto3.Session()
@@ -230,16 +251,19 @@ def setup_for_roll(profile, target_cluster):
         print('\tASG [{}]: {}'.format(len(asgs), ', '.join(asgs)))
         sys.exit(2)
 
-    already_protected_instances = check_instances_protected_from_scale_in(as_client, cluster_instances)
+    already_protected_instances = check_instances_protected_from_scale_in(
+        as_client, cluster_instances)
     if len(already_protected_instances) > 0:
         print('ERROR: EC2 instances associated with ECS cluster have scale in protection.')
         print('Manually remove Scale In protection from the following instances for ecsroll to work properly:')
-        print('\tEC2 Instances: {}'.format(', '.join(already_protected_instances)))
+        print('\tEC2 Instances: {}'.format(
+            ', '.join(already_protected_instances)))
         sys.exit(2)
 
     asg = asgs[0]
 
-    yes_or_exit('Continue, working with ECS cluster \'{}\'?'.format(target_cluster))
+    yes_or_exit(
+        'Continue, working with ECS cluster \'{}\'?'.format(target_cluster))
     yes_or_exit('Continue, working with ASG \'{}\'?'.format(asg))
     print_cluster_instances(cluster_instances)
 
@@ -248,13 +272,16 @@ def setup_for_roll(profile, target_cluster):
 
 def get_new_instance(original, replacement, current):
     original = [[
-        i[INSTANCE_FIELDS.index('ec2InstanceId')], i[INSTANCE_FIELDS.index('containerInstanceArn')]
+        i[INSTANCE_FIELDS.index('ec2InstanceId')], i[INSTANCE_FIELDS.index(
+            'containerInstanceArn')]
     ] for i in original]
     replacement = [[
-        i[INSTANCE_FIELDS.index('ec2InstanceId')], i[INSTANCE_FIELDS.index('containerInstanceArn')]
+        i[INSTANCE_FIELDS.index('ec2InstanceId')], i[INSTANCE_FIELDS.index(
+            'containerInstanceArn')]
     ] for i in replacement]
     current = [[
-        i[INSTANCE_FIELDS.index('ec2InstanceId')], i[INSTANCE_FIELDS.index('containerInstanceArn')]
+        i[INSTANCE_FIELDS.index('ec2InstanceId')], i[INSTANCE_FIELDS.index(
+            'containerInstanceArn')]
     ] for i in current]
     for instance in current:
         if instance not in original and instance not in replacement:
@@ -262,7 +289,8 @@ def get_new_instance(original, replacement, current):
 
 
 def do_cluster_replace(profile, target_cluster):
-    ecs_client, ec2_client, as_client, cluster_instances, asg = setup_for_roll(profile, target_cluster)
+    ecs_client, ec2_client, as_client, cluster_instances, asg = setup_for_roll(
+        profile, target_cluster)
     yes_or_exit('Initiate REPLACE cycle for {} ECS instances ({})?'.format(
         len(cluster_instances), ', '.join([i[0] for i in cluster_instances])
     ))
@@ -272,43 +300,57 @@ def do_cluster_replace(profile, target_cluster):
 
     for i, instance in enumerate(cluster_instances):  # for all original instances
         ec2_instance_id = instance[INSTANCE_FIELDS.index('ec2InstanceId')]
-        ecs_instance_id = instance[INSTANCE_FIELDS.index('containerInstanceArn')]
+        ecs_instance_id = instance[INSTANCE_FIELDS.index(
+            'containerInstanceArn')]
         yes_or_exit('\nPerform replace {} of {}, targeting instance {} [{}]?'.format(
             i+1, len(cluster_instances), ec2_instance_id, ecs_instance_id
         ))
 
         countdown('Waiting for ASG to rightsize ECS cluster', WAIT_TIME)
-        wait_until_instance_count(ecs_client, target_cluster, len(cluster_instances) + 1)
+        wait_until_instance_count(
+            ecs_client, target_cluster, len(cluster_instances) + 1)
         new_instance = get_new_instance(
-            cluster_instances, replacement_instances, get_cluster_instances(ecs_client, target_cluster)
+            cluster_instances, replacement_instances, get_cluster_instances(
+                ecs_client, target_cluster)
         )
-        new_ec2_instance_id = new_instance[INSTANCE_FIELDS.index('ec2InstanceId')]
-        new_ecs_instance_id = new_instance[INSTANCE_FIELDS.index('containerInstanceArn')]
+        new_ec2_instance_id = new_instance[INSTANCE_FIELDS.index(
+            'ec2InstanceId')]
+        new_ecs_instance_id = new_instance[INSTANCE_FIELDS.index(
+            'containerInstanceArn')]
         wait_until_instance_ec2_ok(ec2_client, new_ec2_instance_id)
-        wait_until_instance_ecs_connected(ecs_client, new_ecs_instance_id, target_cluster)
-        print('New instance {} [{}] is up and joined to ECS cluster.'.format(new_ec2_instance_id, new_ecs_instance_id))
+        wait_until_instance_ecs_connected(
+            ecs_client, new_ecs_instance_id, target_cluster)
+        print('New instance {} [{}] is up and joined to ECS cluster.'.format(
+            new_ec2_instance_id, new_ecs_instance_id))
         replacement_instances.append(new_instance)
 
         print('Current cluster members:')
-        print_cluster_instances(get_cluster_instances(ecs_client, target_cluster))
+        print_cluster_instances(
+            get_cluster_instances(ecs_client, target_cluster))
 
         yes_or_exit('\nDrain and terminate original instance {}/{} {} [{}]?'.format(
             i+1, len(cluster_instances), ec2_instance_id, ecs_instance_id
         ))
 
-        wait_until_instance_drained(ecs_client, target_cluster, ecs_instance_id)
+        wait_until_instance_drained(
+            ecs_client, target_cluster, ecs_instance_id)
 
         if i < (len(cluster_instances) - 1):
             #  terminate an original instance
             ec2_client.terminate_instances(InstanceIds=[ec2_instance_id, ])
-            countdown('Terminating original instance {} [{}]'.format(ec2_instance_id, ecs_instance_id), WAIT_TIME)
+            countdown('Terminating original instance {} [{}]'.format(
+                ec2_instance_id, ecs_instance_id), WAIT_TIME)
         else:
             # for the final instance, just downsize cluster & let AS / ECS handle it
-            set_scalein_protection_for_instances(as_client, asg, replacement_instances, True)
+            set_scalein_protection_for_instances(
+                as_client, asg, replacement_instances, True)
             bump_autoscaling_group(as_client, asg, -1)
-            countdown('Returned to original ASG size, waiting for ASG to downsize ECS cluster', WAIT_TIME*2)
-            wait_until_instance_count(ecs_client, target_cluster, len(cluster_instances))
-            set_scalein_protection_for_instances(as_client, asg, replacement_instances, False)
+            countdown(
+                'Returned to original ASG size, waiting for ASG to downsize ECS cluster', WAIT_TIME*2)
+            wait_until_instance_count(
+                ecs_client, target_cluster, len(cluster_instances))
+            set_scalein_protection_for_instances(
+                as_client, asg, replacement_instances, False)
 
     # .. and we're done
     print('ECS cluster has been returned to original size. Current cluster members:')
@@ -316,7 +358,8 @@ def do_cluster_replace(profile, target_cluster):
 
 
 def do_cluster_reboot(profile, target_cluster):
-    ecs_client, ec2_client, as_client, cluster_instances, asg = setup_for_roll(profile, target_cluster)
+    ecs_client, ec2_client, as_client, cluster_instances, asg = setup_for_roll(
+        profile, target_cluster)
     yes_or_exit('Initiate REBOOT cycle for {} ECS instances ({})?'.format(
         len(cluster_instances), ', '.join([i[0] for i in cluster_instances])
     ))
@@ -325,55 +368,73 @@ def do_cluster_reboot(profile, target_cluster):
     bump_autoscaling_group(as_client, asg, 1)
     countdown('Waiting for ASG to upsize ECS cluster', WAIT_TIME)
     # wait until the additional instance joins the cluster
-    wait_until_instance_count(ecs_client, target_cluster, len(cluster_instances) + 1)
+    wait_until_instance_count(
+        ecs_client, target_cluster, len(cluster_instances) + 1)
 
     print('ECS cluster now has the expected number of instances:')
     print_cluster_instances(get_cluster_instances(ecs_client, target_cluster))
-    yes_or_exit('Capacity has been increased; perform rolling reboot of original instances?')
+    yes_or_exit(
+        'Capacity has been increased; perform rolling reboot of original instances?')
     for i, instance in enumerate(cluster_instances):  # for all original instances
         ec2_instance_id = instance[INSTANCE_FIELDS.index('ec2InstanceId')]
-        ecs_instance_id = instance[INSTANCE_FIELDS.index('containerInstanceArn')]
+        ecs_instance_id = instance[INSTANCE_FIELDS.index(
+            'containerInstanceArn')]
         yes_or_exit('\nPerform reboot {} of {}, targeting instance {} [{}]?'.format(
             i+1, len(cluster_instances), ec2_instance_id, ecs_instance_id
         ))
         #  drain instance
-        wait_until_instance_drained(ecs_client, target_cluster, ecs_instance_id)
+        wait_until_instance_drained(
+            ecs_client, target_cluster, ecs_instance_id)
         # 1st reboot instance (this picks up any unapplied security updates when it boots)
         ec2_client.reboot_instances(InstanceIds=[ec2_instance_id, ])
-        countdown('Reboot (1/2) for instance {} [{}]'.format(ec2_instance_id, ecs_instance_id), WAIT_TIME)
+        countdown(
+            'Reboot (1/2) for instance {} [{}]'.format(ec2_instance_id, ecs_instance_id), WAIT_TIME)
         wait_until_instance_ec2_ok(ec2_client, ec2_instance_id)
-        wait_until_instance_ecs_connected(ecs_client, ecs_instance_id, target_cluster)
+        wait_until_instance_ecs_connected(
+            ecs_client, ecs_instance_id, target_cluster)
         # 2nd reboot of instance (boots to new kernel, if it was updated)
         ec2_client.reboot_instances(InstanceIds=[ec2_instance_id, ])
-        countdown('Reboot (2/2) for instance {} [{}]'.format(ec2_instance_id, ecs_instance_id), WAIT_TIME)
+        countdown(
+            'Reboot (2/2) for instance {} [{}]'.format(ec2_instance_id, ecs_instance_id), WAIT_TIME)
         wait_until_instance_ec2_ok(ec2_client, ec2_instance_id)
-        wait_until_instance_ecs_connected(ecs_client, ecs_instance_id, target_cluster)
+        wait_until_instance_ecs_connected(
+            ecs_client, ecs_instance_id, target_cluster)
         #  mark as ACTIVE and verify that it is
         print('Marking ECS instance {} as ACTIVE'.format(ecs_instance_id))
         ecs_client.update_container_instances_state(
-            cluster=target_cluster, containerInstances=[ecs_instance_id, ], status='ACTIVE'
+            cluster=target_cluster, containerInstances=[
+                ecs_instance_id, ], status='ACTIVE'
         )
-        wait_until_instance_status(ecs_client, target_cluster, ec2_instance_id, 'ACTIVE')
+        wait_until_instance_status(
+            ecs_client, target_cluster, ec2_instance_id, 'ACTIVE')
         print('Current state of cluster:')
-        print_cluster_instances(get_cluster_instances(ecs_client, target_cluster))
+        print_cluster_instances(
+            get_cluster_instances(ecs_client, target_cluster))
 
-    yes_or_exit('Reboots completed; return cluster to original size by draining and terminating overflow instance?')
+    yes_or_exit(
+        'Reboots completed; return cluster to original size by draining and terminating overflow instance?')
 
     # drain overflow instance
-    overflow_ids = get_overflow_instance_ids(cluster_instances, get_cluster_instances(ecs_client, target_cluster))
+    overflow_ids = get_overflow_instance_ids(
+        cluster_instances, get_cluster_instances(ecs_client, target_cluster))
     if len(overflow_ids) != 1:
         print('ERROR: Unexpected number of overflow instances ({})'.format(', '.join(
             [oid['ec2'] for oid in overflow_ids]
         )))
         print('       Exiting, manual cleanup likely needed')
-    wait_until_instance_drained(ecs_client, target_cluster, overflow_ids[0]['ecs'])
+    wait_until_instance_drained(
+        ecs_client, target_cluster, overflow_ids[0]['ecs'])
 
     # downsize cluster & wait until overflow instance is gone
-    set_scalein_protection_for_instances(as_client, asg, cluster_instances, True)
+    set_scalein_protection_for_instances(
+        as_client, asg, cluster_instances, True)
     bump_autoscaling_group(as_client, asg, -1)
-    countdown('Returned to original ASG size, waiting for ASG to downsize ECS cluster', WAIT_TIME)
-    wait_until_instance_count(ecs_client, target_cluster, len(cluster_instances))
-    set_scalein_protection_for_instances(as_client, asg, cluster_instances, False)
+    countdown(
+        'Returned to original ASG size, waiting for ASG to downsize ECS cluster', WAIT_TIME)
+    wait_until_instance_count(
+        ecs_client, target_cluster, len(cluster_instances))
+    set_scalein_protection_for_instances(
+        as_client, asg, cluster_instances, False)
 
     # .. and we're done
     print('ECS cluster has been returned to original size:')
@@ -381,18 +442,22 @@ def do_cluster_reboot(profile, target_cluster):
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(prog='ecsroll', description='AWS ECS Maintenance Script')
+    parser = argparse.ArgumentParser(
+        prog='ecsroll', description='AWS ECS Maintenance Script')
     parser.add_argument(
         '--cluster', '-c', nargs='?', default=DEFAULT_CLUSTER,
-        help='Name of ECS cluster to maintain (default: \'{0}\')'.format(DEFAULT_CLUSTER)
+        help='Name of ECS cluster to maintain (default: \'{0}\')'.format(
+            DEFAULT_CLUSTER)
     )
     parser.add_argument(
         '--profile', '-p', nargs='?', default=DEFAULT_PROFILE,
-        help='Name of AWS profile to target (default: \'{0}\')'.format(DEFAULT_PROFILE)
+        help='Name of AWS profile to target (default: \'{0}\')'.format(
+            DEFAULT_PROFILE)
     )
     parser.add_argument(
         '--wait', '-w', nargs='?', default=DEFAULT_WAIT, type=int,
-        help='Base for timer to wait between actions (default: \'{0}\')'.format(DEFAULT_WAIT)
+        help='Base for timer to wait between actions (default: \'{0}\')'.format(
+            DEFAULT_WAIT)
     )
     parser.add_argument(
         '--provider', '-r', nargs='?', default=DEFAULT_PROVIDER, choices=[PROVIDER_PROFILE, PROVIDER_ENV],
@@ -415,8 +480,10 @@ if __name__ == '__main__':
     if args.provider == PROVIDER_PROFILE:
         session = boto3.Session()
         if args.profile not in session.available_profiles:
-            print('ERROR: AWS profile \'{0}\' not configured.'.format(args.profile))
-            print('       Available AWS profiles: {0}'.format(', '.join(session.available_profiles)))
+            print('ERROR: AWS profile \'{0}\' not configured.'.format(
+                args.profile))
+            print('       Available AWS profiles: {0}'.format(
+                ', '.join(session.available_profiles)))
             sys.exit(2)
         print('Using AWS profile \'{0}\''.format(args.profile))
     print('Initiating \'{1}\' maintenance for ECS cluster \'{0}\'...'.format(


### PR DESCRIPTION
In my particular case, using a profile is a must; the scripts set `AWS_PROFILE` and all apps respect that value; changed the default value for the profile argument to check for `AWS_PROFILE`, if not, use the default as it was before.

Added the region argument, as since most of the time there isn't a region set in the config files, using SSO, and setting `AWS_DEFAULT_REGION` every time is not the best. Passing  `region_name` as `None` to the boto3 `Session` will default to the current behaviour, fetching from the config or the env var.

Also formatted in vscode, that's why there are so many changes.